### PR TITLE
Use relative path for IDR_DRIVER in ObjectExplorer.rc

### DIFF
--- a/ObjectExplorer/ObjectExplorer.rc
+++ b/ObjectExplorer/ObjectExplorer.rc
@@ -412,7 +412,15 @@ IDI_TYPES               ICON                    "res\\types.ico"
 // BIN
 //
 
-IDR_DRIVER              BIN                     "C:\\Dev\\ObjectExplorer\\x64\\Release\\KObjExp.sys"
+#if defined(_DEBUG) && defined(_WIN64)
+IDR_DRIVER              BIN                     "..\\x64\\Debug\\KObjExp.sys"
+#elif defined(_DEBUG) && !defined(_WIN64)
+IDR_DRIVER              BIN                     "..\\Debug\\KObjExp.sys"
+#elif !defined(_DEBUG) && defined(_WIN64)
+IDR_DRIVER              BIN                     "..\\x64\\Release\\KObjExp.sys"
+#else
+IDR_DRIVER              BIN                     "..\\Release\\KObjExp.sys"
+#endif
 
 #endif    // English (United Kingdom) resources
 /////////////////////////////////////////////////////////////////////////////

--- a/ObjectExplorer/ObjectExplorer.vcxproj
+++ b/ObjectExplorer/ObjectExplorer.vcxproj
@@ -131,7 +131,7 @@
     <ResourceCompile>
       <Culture>0x0409</Culture>
       <AdditionalIncludeDirectories>$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
     <Midl>
       <MkTypLibCompatible>false</MkTypLibCompatible>
@@ -196,7 +196,7 @@
     <ResourceCompile>
       <Culture>0x0409</Culture>
       <AdditionalIncludeDirectories>$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
     <Midl>
       <MkTypLibCompatible>false</MkTypLibCompatible>


### PR DESCRIPTION
With this, users can build ObjectExplorer without editing ObjectExplorer.rc manually.