### PR TITLE
Add embedding driver in ObjectExplorer.rc

### DIFF
--- a/ObjectExplorer/ObjectExplorer.rc
+++ b/ObjectExplorer/ObjectExplorer.rc
@@ -438,6 +438,21 @@ BEGIN
     ATL_IDS_MRU_FILE        "Open this document"
 END
 
+/////////////////////////////////////////////////////////////////////////////
+//
+// BIN
+//
+
+#if defined(_DEBUG) && defined(_WIN64)
+IDR_DRIVER              BIN                     "..\\x64\\Debug\\KObjExp.sys"
+#elif defined(_DEBUG) && !defined(_WIN64)
+IDR_DRIVER              BIN                     "..\\Debug\\KObjExp.sys"
+#elif !defined(_DEBUG) && defined(_WIN64)
+IDR_DRIVER              BIN                     "..\\x64\\Release\\KObjExp.sys"
+#else
+IDR_DRIVER              BIN                     "..\\Release\\KObjExp.sys"
+#endif
+
 #endif    // English (United States) resources
 /////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Originally, KObjExp.sys was embedded in ObjectExplorer.exe, so that the driver can be automatically installed on first launch. But I noticed that commit [69becd6](https://github.com/zodiacon/ObjectExplorer/commit/69becd62a44128865796447f03c498ed851b40bb#diff-5c04c2b0c39702f17c02fb31882a485aL410) removed the embedded driver.

I add it back with the change in this PR, and it seems to work fine. I'm curious what is the reason for removing the kernel driver from EXE?